### PR TITLE
Made twitter card header match the buttons above it

### DIFF
--- a/_pages/community.html
+++ b/_pages/community.html
@@ -77,7 +77,9 @@ title: Community
                 <ul class="list-group twitter-links">
                     <!-- Header -->
                     <li class="list-group-item header">
-                        <h5 style="margin: 0 auto">Follow us on Twitter</h5>
+                        <div class="d-flex w-100">
+                            <h4 class="mb-1">Follow us on Twitter</h4>
+                        </div>
                     </li>
 
                     <!-- CompSoc -->

--- a/_pages/community.html
+++ b/_pages/community.html
@@ -77,9 +77,7 @@ title: Community
                 <ul class="list-group twitter-links">
                     <!-- Header -->
                     <li class="list-group-item header">
-                        <div class="d-flex w-100">
-                            <h4 class="mb-1">Follow us on Twitter</h4>
-                        </div>
+                        <h5 style="text-align: center; width: 100%; margin-bottom: 0">Follow us on Twitter</h5>
                     </li>
 
                     <!-- CompSoc -->

--- a/_pages/community.html
+++ b/_pages/community.html
@@ -77,8 +77,8 @@ title: Community
                 <ul class="list-group twitter-links">
                     <!-- Header -->
                     <li class="list-group-item header">
-                        <div class="d-flex w-100">
-                            <h4 class="mb-1">Follow us on Twitter</h4>
+                        <div class="d-flex justify-content-center w-100">
+                            <h5 class="mb-0">Follow us on Twitter</h5>
                         </div>
                     </li>
 

--- a/_pages/community.html
+++ b/_pages/community.html
@@ -77,7 +77,7 @@ title: Community
                 <ul class="list-group twitter-links">
                     <!-- Header -->
                     <li class="list-group-item header">
-                        <h5 style="text-align: center; width: 100%; margin-bottom: 0">Follow us on Twitter</h5>
+                        <h5 style="margin: 0 auto">Follow us on Twitter</h5>
                     </li>
 
                     <!-- CompSoc -->


### PR DESCRIPTION
Another very small commit, but it seemed odd having the "follow us on Twitter" being in a totally different font to the "follow us on Facebook" above it. There is some slightly nasty inline CSS, but it didn't seem worth moving it off into the main Sass file?

![screen shot 2017-07-27 at 20 03 17](https://user-images.githubusercontent.com/8237136/28687799-8db3b4e2-7307-11e7-8d51-8627eac92193.png)
