### PR TITLE
Update partner page to temporary page

### DIFF
--- a/_data/partners.yml
+++ b/_data/partners.yml
@@ -1,17 +1,17 @@
-- url: https://www.amazon.jobs/
-  img: static/img/partners/amazon.png
+# - url: https://www.amazon.jobs/
+#   img: static/img/partners/amazon.png
 
-- url: https://www.bloomberg.com/careers/
-  img: static/img/partners/bloomberg.svg
+# - url: https://www.bloomberg.com/careers/
+#   img: static/img/partners/bloomberg.svg
 
-- url: https://careers.microsoft.com/
-  img: static/img/partners/microsoft.png
+# - url: https://careers.microsoft.com/
+#   img: static/img/partners/microsoft.png
 
-- url: https://careers.jpmorgan.com/
-  img: static/img/partners/jpmorgan.png
+# - url: https://careers.jpmorgan.com/
+#   img: static/img/partners/jpmorgan.png
 
-- url: https://king.com/
-  img: static/img/partners/king.png
+# - url: https://king.com/
+#   img: static/img/partners/king.png
 
-- url: https://www.sumdog.com/
-  img: static/img/partners/sumdog.png
+# - url: https://www.sumdog.com/
+#   img: static/img/partners/sumdog.png

--- a/_pages/partners.md
+++ b/_pages/partners.md
@@ -5,6 +5,8 @@ title: "Partners"
 Here at CompSoc we are supported by some great companies that are passionate about engaging in student life.
 We are eternally grateful for their support over the years.
 
+We're currently updating our partner list for the 2017-2018 academic year. Please check back after freshers' week to see who we'll be working with this year!
+
 <div class="partners">
 	{% for partner in site.data.partners %}
 		{% assign imgStart = partner.img | slice: 0, 4 %}


### PR DESCRIPTION
While the list of partners for 2017-2018 is being finalised, plop a note
in the partners' page to let people know to expect changes.

See issue #46.