### PR TITLE
Update README to use the Jekyll 'serve' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ If you're on Windows, please contribute some instructions. You'll hopefully be a
 If you have `bundler` installed, type:
 
 - `bundle`, to install the Gemfile packages
-- `bundle exec jekyll build --watch` to build and watch the directory for changes
+- `bundle exec jekyll serve` to build and watch the directory for changes

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ If you're on Windows, please contribute some instructions. You'll hopefully be a
 If you have `bundler` installed, type:
 
 - `bundle`, to install the Gemfile packages
-- `bundle exec jekyll serve` to build and watch the directory for changes
+- `bundle exec jekyll serve` to host a local server that will watch the directory for changes


### PR DESCRIPTION
`build --watch` does seem to build the site and automatically rebuild it, but you don't get the integrated web server which is kinda necessary for most people.