### PR TITLE
Bootstrap to beta (Fixes #57)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -48,7 +48,7 @@
     <title>{{ seo_title }}</title>
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
 
     <!-- FontAwesome CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-toggleable-md navbar-light">
+<nav class="navbar navbar-expand-lg navbar-light">
     <div class="container">
         {% if page.url != "/" %}
             {% assign navbar-class = "navbar-toggler-with-logo" %}
@@ -7,7 +7,7 @@
         <button class="navbar-toggler {{ navbar-class }}" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-    
+
         {% if page.url != "/" %}
         <a class="navbar-brand" href="{{ site.baseurl }}/">
             <img src="{{ site.baseurl }}/static/img/compsoc-horizontal.svg" alt="CompSoc Edinburgh Logo">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light">
-    <div class="container">
+    <div class="container justify-content-center justify-content-sm-between">
         {% if page.url != "/" %}
             {% assign navbar-class = "navbar-toggler-with-logo" %}
         {% endif %}
@@ -10,7 +10,7 @@
 
         {% if page.url != "/" %}
         <a class="navbar-brand" href="{{ site.baseurl }}/">
-            <img src="{{ site.baseurl }}/static/img/compsoc-horizontal.svg" alt="CompSoc Edinburgh Logo">
+            <img src="{{ site.baseurl }}/static/img/compsoc-horizontal.svg" alt="CompSoc Edinburgh Logo" class="pl-1 pl-sm-0">
         </a>
         {% endif %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,9 +17,9 @@
         {% endif %}
 
         <!-- jQuery first, then Tether, then Bootstrap JS. -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+        <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
 
         <!-- Page specific content -->
         {% if page.has_include %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
 
 <div class="row">
     <div class="col-xl-2">
-        <div class="hidden-xl-up">
+        <div class="d-xl-none">
             {% include navigate-collection.html %}
         </div>
 
@@ -49,7 +49,7 @@ layout: default
         </div>
     </div>
     <div class="col-xl-10">
-        <div class="hidden-lg-down">
+        <div class="d-none d-xl-block">
             {% include navigate-collection.html %}
         </div>
         <h1>{% if page.longtitle %}{{ page.longtitle }}{% else %}{{ page.title }}{% endif %}</h5>

--- a/_pages/community.html
+++ b/_pages/community.html
@@ -43,7 +43,7 @@ title: Community
         <div class="col-lg-4">
             <!-- Discord -->
             <div class="card mb-3 text-center">
-                <a href="{{ site.baseurl }}/chat" class="btn btn-discord btn-block" data-toggle="modal" data-target="#chatModal" style="cursor: pointer;">
+                <a href="{{ site.baseurl }}/chat" class="btn btn-discord btn-block" data-toggle="modal" data-target="#chatModal">
                     <img src="{{ site.baseurl }}/static/img/Discord-Logo+Wordmark-White.svg" style="height: 90px; max-width: 100%">
                     <p>Chat with our community</p>
                     <p>We use Discord and IRC.</p>
@@ -51,8 +51,8 @@ title: Community
             </div>
 
             <!-- Better Informatics -->
-            <div class="list-group mb-3">
-                <a class="list-group-item list-group-item-action p-3 d-flex justify-content-center align-items-center" href="https://betterinformatics.com/">
+            <div class="card mb-3">
+                <a class="btn btn-betterinf" href="https://betterinformatics.com/">
                     <h4 class="card-title">Better Informatics</h4>
                     <img src="{{ site.baseurl }}/static/img/better-informatics-thumb.png" style="max-width: 100%">
                     <p class="card-text">Academic support and information</p>
@@ -82,18 +82,18 @@ title: Community
                     <!-- CompSoc -->
                     <a class="list-group-item list-group-item-action" style="color: rgb(59, 148, 217)" href="https://twitter.com/compsoc">
                         <img src="https://pbs.twimg.com/profile_images/506603183498485760/iZY-bL-6_400x400.png" class="img img-fluid" style="border-radius: 50%; width: 25%; margin-right: 10px; max-width: 100px;"></img>
-                        <h5 class="mb-1">@CompSoc</h5>
+                        <h5>@CompSoc</h5>
                     </a>
 
                     <!-- Hacktheburgh -->
                     <a class="list-group-item list-group-item-action" style="color: rgb(59, 148, 217)" href="https://twitter.com/hacktheburgh">
                         <img src="https://pbs.twimg.com/profile_images/843977653732495360/RLdA8AiG_400x400.jpg" class="img img-fluid" style="border-radius: 50%; width: 25%; margin-right: 10px; max-width: 100px"></img>
-                        <h5 class="mb-1">@hacktheburgh</h5>
+                        <h5>@hacktheburgh</h5>
                     </a>
                     <!-- SIGINT -->
                     <a class="list-group-item list-group-item-action" style="color: rgb(59, 148, 217)" href="https://twitter.com/siginthq">
                         <img src="https://pbs.twimg.com/profile_images/788344487613493248/7iK1n0GW_400x400.jpg" class="img img-fluid sigint-logo-community" />
-                        <h5 class="mb-1">@SIGINThq</h5>
+                        <h5>@SIGINThq</h5>
                     </a>
                 </div>
             </div>

--- a/_pages/sigs.md
+++ b/_pages/sigs.md
@@ -10,7 +10,7 @@ CompSoc offers SIGs promotion, some money, support, and a place on the committee
 
 ### Our SIGs
 <div class="d-flex flex-wrap justify-content-center justify-content-sm-start mb-2">
-    <div class="sigs-item bg-inverse">
+    <div class="sigs-item" style="background-color: #292b2c">
         <a href="http://sigint.mx" class="d-inline-block" style="padding: 25px">
             <img src="{{ site.baseurl }}/static/img/sigs/sigint-logo.png" height="200px" class="float-left" />
         </a>

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -11,15 +11,15 @@ We are the team that brings you the best experience in all things Informatics.
 {% assign committee = (site.data.committee | sort) | reverse %}
 
 <div class="row">
-	<div class="col-xl-2 col-lg-3 push-lg-8 col-sm-12">
+	<div class="col-xl-2 col-lg-3 order-lg-2 col-sm-12">
 		<nav id="cohorts" class="nav nav-pills list-group" role="tablist">
 			{% for cohort in committee %}{% if cohort.year %}
-				<a class="list-group-item justify-content-center"
+				<a class="d-flex list-group-item justify-content-center"
 						data-toggle="pill"
 						role="pill"
 						href="#cohort-{{ cohort.year | slugify }}"
 						{% if committee[0] == cohort %}
-						class="list-group-item justify-content-center active"
+						class="d-flex list-group-item justify-content-center active"
 						aria-expanded="true"
 						{% endif %}
 				>{{ cohort.year }}</a>
@@ -28,7 +28,7 @@ We are the team that brings you the best experience in all things Informatics.
 	</div>
 	<!-- -->
 	<!-- -->
-	<div class="col-lg-8 pull-lg-3 pull-xl-2 col-sm-12">
+	<div class="col-lg-8 pull-lg-3 order-lg-1 col-sm-12">
 		<div class="tab-content">
 		{% for cohort in committee %}
 			{% if cohort.year %}
@@ -38,7 +38,7 @@ We are the team that brings you the best experience in all things Informatics.
 				role="tabpanel"
 			>
 			<ul class="list-group mb-4">
-				<li class="list-group-item justify-content-between">
+				<li class="d-flex list-group-item justify-content-between">
 					<h5 class="mb-0">{{ cohort.year }}</h5>
 					<span>
 						<!--<a class="btn disabled btn-sm btn-outline-danger" href="#">Financial Report</a>-->
@@ -48,7 +48,7 @@ We are the team that brings you the best experience in all things Informatics.
 					</span>
 				</li>
 				{% for member in cohort.members %}
-					<li class="list-group-item justify-content-between">
+					<li class="d-flex list-group-item justify-content-between">
 						<strong>{{ member.role }}</strong>
 						<span>
 							{% if member.url %}

--- a/_sass/_community.sass
+++ b/_sass/_community.sass
@@ -30,7 +30,18 @@
             background-color: #5aa9d6
             border-color: #5aa9d6
 
+    .btn-betterinf
+        color: #495057
+        &:hover
+            background-color: #f8f9fa
+        &:active
+            background-color: #e9ecef
+
+
 .twitter-links 
     .header
         background-color: rgb(59, 148, 217)
         color: white
+
+    .list-group-item > h5
+        display: inline

--- a/_sass/_nav.sass
+++ b/_sass/_nav.sass
@@ -3,14 +3,9 @@
 
 // On smaller screens (but not smallest)
 @media (min-width: 576px)
-    .navbar-toggler-with-logo
-        position: absolute
-
     .navbar-brand
         display: block
-        > img
-            display: block
-            margin: auto
+        margin: auto
 
 // On wide screens
 @media (min-width: 992px)

--- a/_sass/_nav.sass
+++ b/_sass/_nav.sass
@@ -3,6 +3,9 @@
 
 // On smaller screens (but not smallest)
 @media (min-width: 576px)
+    .navbar-toggler-with-logo
+        position: absolute
+
     .navbar-brand
         display: block
         margin: auto

--- a/static/css/main.sass
+++ b/static/css/main.sass
@@ -27,7 +27,7 @@ a
 
 .minutes-cell, .minutes-hidden-cell
     width: 10rem
-    padding: 0
+    padding: 10px
     margin-right: 5px
     margin-bottom: 5px
 


### PR DESCRIPTION
Migrated the site to using the new Bootstrap v4.0.0-beta.2

Potential issue regarding the centre alignment of the CompSoc logo on mobile: (i.e. it centres in the space left by the menu toggle, as opposed to the full screen width, and snaps to the right on `xs`)

<img width="853" alt="screen shot 2017-11-03 at 12 25 32" src="https://user-images.githubusercontent.com/8237136/32373632-22f3ba20-c092-11e7-97d5-6813a4548b51.png">

Other than that, should be good to go. (Fixes #57 )