### PR TITLE
Remove VP from the list of executive roles

### DIFF
--- a/_posts/2018-03-07-march-agm.md
+++ b/_posts/2018-03-07-march-agm.md
@@ -45,7 +45,7 @@ The positions available are as follows:
 
 - Send president@comp-soc.com your manifesto (max 200 words) **by Tuesday 3pm 20th March 2018** (was Sunday, now Tuesday).
 - [Make sure you have CompSoc membership.](/join) You cannot run for election without membership.
-- Prepare your speech. Length is 2 minutes for executive roles (Pres, VP, Secretary, Treasurer) and 1 minute for the other roles.
+- Prepare your speech. Length is 2 minutes for executive roles (Pres, Secretary, Treasurer) and 1 minute for the other roles.
 
 There are also constitutional amendments, some required by EUSA, which can be found here: https://github.com/compsoc-edinburgh/constitution/pulls.
 


### PR DESCRIPTION
Constitution & EUSA rules state that only President, Secretary and Treasurer are exec roles, while everything else is defined as an additional role.