### PR TITLE
Remove sigweb channel from default channels

### DIFF
--- a/_pages/irc.md
+++ b/_pages/irc.md
@@ -44,4 +44,4 @@ If you already know your way around IRC, here are the connection details:
 * Server: `irc.imaginarynet.uk`
 * SSL: `yes`
 * Port: `6697`
-* Channel: `#compsoc,#sigint,#tardis`
+* Channel: `#compsoc,#networking,#sigint,#tardis`

--- a/_pages/irc.md
+++ b/_pages/irc.md
@@ -44,4 +44,4 @@ If you already know your way around IRC, here are the connection details:
 * Server: `irc.imaginarynet.uk`
 * SSL: `yes`
 * Port: `6697`
-* Channel: `#compsoc,#sigweb,#sigint,#tardis`
+* Channel: `#compsoc,#sigint,#tardis`


### PR DESCRIPTION
The `#sigweb` channel isn't very active, so I don't think it's worth 
advertising it as a default channel. Might be worth suggesting something more
active like `#networking`?